### PR TITLE
chore: enforce patched Rollup version via overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "resolve-url-loader": "^5.0.0"
   },
   "overrides": {
-    "glob": "^10.5.0"
+    "glob": "^10.5.0",
+    "rollup": "^2.80.0"
   }
 }


### PR DESCRIPTION
### Motivation
- Constrain transitive `rollup` resolution to a patched range (`^2.80.0`) to address the Dependabot advisory for an arbitrary file write / path traversal vulnerability.

### Description
- Added an `overrides` entry in `package.json` (`"rollup": "^2.80.0"`) so downstream packages resolve a patched Rollup version and committed the change.

### Testing
- Ran `npm install --no-audit --no-fund`, which failed with `403 Forbidden` from the npm registry so `package-lock.json` could not be regenerated in this environment. 
- Ran `npm ls rollup`, which still shows `rollup@2.79.2` as invalid until a successful `npm install` updates the lockfile in a networked environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6817908908331abd7ed3d64e01822)